### PR TITLE
Remove SZ_LOWER setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Changes in this fork compared to the original:
  - Enabling/disabling features is now done by env variables instead of parameters.
  - Dropped support for GCC/Gfortran since DragonEgg has not been ported to newer LLVM.
  - Removed scripts and configs for running SPEC CPU2006.
- - Split lowering into a separate option instead of being enabled by SZ_CODE
 
 Help is wanted for testing and fixing the remaining crashes.
 Despite the crashes, this is still useful for enabling heap randomizations.
@@ -82,7 +81,7 @@ and is compatible with C and C++ inputs.
 
 To manually compile a program in `foo.c` with Stabilizer, run:
 ```
-export SZ_CODE=1 SZ_HEAP=1 SZ_STACK=1 SZ_LOWER=1 SZ_LINK=1
+export SZ_CODE=1 SZ_HEAP=1 SZ_STACK=1 SZ_LINK=1
 $ szcc foo.c -o foo
 ```
 The exported env flags enable the various randomizations, and may be used in any
@@ -91,7 +90,6 @@ combination.
 * `SZ_CODE` Move functions repeatedly during execution.
 * `SZ_HEAP` Randomize stack location.
 * `SZ_STACK` Move stack repeatedly during execution.
-* `SZ_LOWER` Switch/Invoke/Intrinsic lowering
 * `SZ_LINK` Randomly reorder linking (only once, during compilation)
 * `SZ_VERBOSE` Turns on verbose debugging output from `szcc` during compile.
 

--- a/common.mk
+++ b/common.mk
@@ -25,7 +25,6 @@ endif
 SZ_CODE=1
 SZ_HEAP=1
 SZ_STACK=1
-SZ_LOWER=1
 
 # Set the default shared library filename suffix
 SHLIB_SUFFIX ?= so

--- a/szcc
+++ b/szcc
@@ -232,6 +232,9 @@ def init():
         verboseprint("Enabling randomized code location")
         stabilize = True
         opts.append('stabilize-code')
+        opts.append('lower-intrinsics')
+        opts.append('lowerswitch')
+        opts.append('lowerinvoke')
 
     if 'SZ_STACK' in os.environ and os.environ['SZ_STACK'] == '1':
         verboseprint("Enabling randomized stack location")
@@ -242,12 +245,6 @@ def init():
         verboseprint("Enabling randomized heap location")
         stabilize = True
         opts.append('stabilize-heap')
-
-    if 'SZ_LOWER' in os.environ and os.environ['SZ_LOWER'] == '1':
-        verboseprint("Enabling Switch/Invoke/Intrinsic lowering")
-        opts.append('lower-intrinsics')
-        opts.append('lowerswitch')
-        opts.append('lowerinvoke')
 
     if 'SZ_LINK' in os.environ and os.environ['SZ_LINK'] == '1':
         verboseprint("Enabling randomized link order")


### PR DESCRIPTION
Remove SZ_LOWER setting, code lowering is now auto-enabled by the SZ_CODE again.